### PR TITLE
Add seperate rosters page that get's fed from data directory files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ _site
 .jekyll-cache
 .jekyll-metadata
 vendor
+.DS_Store

--- a/_data/teams/brooklyn_nets.yml
+++ b/_data/teams/brooklyn_nets.yml
@@ -1,0 +1,26 @@
+name: Brooklyn Nets
+order: 1
+players:
+  - name: Aidan Bordeleau
+    age: 18
+    position: PF
+    school: Quinnipiac University
+    hometown: Cranston, RI
+    height: 6'2
+    weight: 185
+
+  - name: Justin Patalano
+    age: 15
+    position: PG
+    school: Cranston High School West
+    hometown: Cranston, RI
+    height: 5'10
+    weight: 140
+
+  - name: Jared Patalano
+    age: 13
+    position: SG
+    school: Hope Highlands Middle School
+    hometown: Cranston, RI
+    height: 5'6
+    weight: 105

--- a/_data/teams/free_agents.yml
+++ b/_data/teams/free_agents.yml
@@ -1,0 +1,33 @@
+name: Free Agents
+players:
+  - name: C.J. Bordeleau
+    age: 32
+    position: C
+    school: University of Rhode Island
+    hometown: Cranston, RI
+    height: 6'3
+    weight: 205
+
+  - name: Dillon Bordeleau
+    age: 22
+    position: PF
+    school: Worcester Polytechnic Institute
+    hometown: Cranston, RI
+    height: 6'1
+    weight: 180
+
+  - name: Todd Patalano
+    age: 47
+    position: SG
+    school: Roger Williams University
+    hometown: Cranston, RI
+    height: 6'0
+    weight: 180
+
+  - name: Matthew Pisaturo
+    age: 21
+    position: SG
+    school: Rhode Island College
+    hometown: Cranston, RI
+    height: 5'6
+    weight: 185

--- a/_data/teams/new_york_knicks.yml
+++ b/_data/teams/new_york_knicks.yml
@@ -1,0 +1,26 @@
+name: New York Knicks
+order: 2
+players:
+  - name: Jason Patlano
+    age: 17
+    position: PF
+    school: Cranston High School West
+    hometown: Cranston, RI
+    height: 5'10
+    weight: 150
+
+  - name: Jay Carosi
+    age: 38
+    position: C
+    school: Providence College
+    hometown: Cranston, RI
+    height: 5'8
+    weight: 198
+
+  - name: Edward Cappelli
+    age: 14
+    position: SG
+    school: Bishop Hendricken High School
+    hometown: Cranston, RI
+    height: 5'1
+    weight: 105

--- a/rosters.html
+++ b/rosters.html
@@ -1,0 +1,32 @@
+---
+layout: page
+title: Rosters
+permalink: /rosters/
+---
+
+{% for team_hash in site.data.teams reversed %}
+  {% assign team = team_hash[1] %}
+  <h2>{{ team.name }}</h2>
+  <table>
+    <tr>
+      <th>Player</th>
+      <th>Age</th>
+      <th>Position</th>
+      <th>School</th>
+      <th>Hometown</th>
+      <th>Height</th>
+      <th>Weight</th>
+    </tr>
+    {% for player in team.players %}
+      <tr>
+        <td>{{ player.name }}</td>
+        <td>{{ player.age }}</td>
+        <td>{{ player.position }}</td>
+        <td>{{ player.school }}</td>
+        <td>{{ player.hometown }}</td>
+        <td>{{ player.height }}</td>
+        <td>{{ player.weight }}lbs</td>
+      </tr>
+    {% endfor %}
+  </table>
+{% endfor %}


### PR DESCRIPTION
Jekyll allows for data files to hold data that you then can use to loop
over during the build. Details here: https://jekyllrb.com/docs/datafiles/

This PR adds a roster page and uses 3 teams data files written in yml to
populate it. This way only the yml files will need to be changed to
update the rosters in the future.

<img width="816" alt="Screen Shot 2020-07-01 at 4 51 06 PM" src="https://user-images.githubusercontent.com/453191/86290234-1becbe80-bbbb-11ea-9a39-2a2db1367f52.png">

